### PR TITLE
Bump openseadragon version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ openseadragon_composer_item: "islandora/openseadragon:1.0.0"
 openseadragon_composer_root: "/var/www/html/drupal"
 openseadragon_sites:
   - default
-openseadragon_version: 2.2.1
+openseadragon_version: 2.4.1
 openseadragon_temp_folder: /tmp
 
 openseadragon_iiiv_set_var: false


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1228

# What does this Pull Request do?

Bumps openseadragon to 2.4.1

# How should this be tested?

- Change `requirements.yml` in claw-playbook to include this branch.  
- `vagrant up`
- Make sure openseadragon still works.

# Interested parties
@kayakr  @Islandora-Devops/committers
